### PR TITLE
Scanner crashing sometimes when launched - bugfix 

### DIFF
--- a/src/SickSafetyscannersLifeCycle.cpp
+++ b/src/SickSafetyscannersLifeCycle.cpp
@@ -80,6 +80,9 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SickSa
     std::bind(
       &SickSafetyscannersLifeCycle::getFieldData, this, std::placeholders::_1, std::placeholders::_2));
 
+  m_msg_creator = std::make_unique<sick::MessageCreator>(
+    m_frame_id, m_time_offset, m_range_min, m_range_max, m_angle_offset, m_min_intensities);
+
   // Bind callback
   std::function<void(const sick::datastructure::Data&)> callback =
     std::bind(&SickSafetyscannersLifeCycle::receiveUDPPaket, this, std::placeholders::_1);
@@ -117,8 +120,7 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SickSa
   // Start async receiving and processing of sensor data
   m_device->run();
   m_device->changeSensorSettings(m_communications_settings);
-  m_msg_creator = std::make_unique<sick::MessageCreator>(
-    m_frame_id, m_time_offset, m_range_min, m_range_max, m_angle_offset, m_min_intensities);
+    
   m_laser_scan_publisher->on_activate();
   m_extended_laser_scan_publisher->on_activate();
   m_output_paths_publisher->on_activate();

--- a/src/SickSafetyscannersLifeCycle.cpp
+++ b/src/SickSafetyscannersLifeCycle.cpp
@@ -79,6 +79,14 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SickSa
     "field_data",
     std::bind(
       &SickSafetyscannersLifeCycle::getFieldData, this, std::placeholders::_1, std::placeholders::_2));
+    
+  // Read sensor specific configurations
+  readTypeCodeSettings();
+
+  if (m_use_pers_conf)
+  {
+    readPersistentConfig();
+  }
 
   m_msg_creator = std::make_unique<sick::MessageCreator>(
     m_frame_id, m_time_offset, m_range_min, m_range_max, m_angle_offset, m_min_intensities);
@@ -100,14 +108,6 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SickSa
   }
 
   RCLCPP_INFO(this->get_logger(), "Communication to Sensor set up");
-
-  // Read sensor specific configurations
-  readTypeCodeSettings();
-
-  if (m_use_pers_conf)
-  {
-    readPersistentConfig();
-  }
 
   RCLCPP_INFO(this->get_logger(), "Node Configured"); 
 

--- a/src/SickSafetyscannersLifeCycle.cpp
+++ b/src/SickSafetyscannersLifeCycle.cpp
@@ -80,16 +80,6 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SickSa
     std::bind(
       &SickSafetyscannersLifeCycle::getFieldData, this, std::placeholders::_1, std::placeholders::_2));
     
-  // Read sensor specific configurations
-  readTypeCodeSettings();
-
-  if (m_use_pers_conf)
-  {
-    readPersistentConfig();
-  }
-
-  m_msg_creator = std::make_unique<sick::MessageCreator>(
-    m_frame_id, m_time_offset, m_range_min, m_range_max, m_angle_offset, m_min_intensities);
 
   // Bind callback
   std::function<void(const sick::datastructure::Data&)> callback =
@@ -108,6 +98,16 @@ rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SickSa
   }
 
   RCLCPP_INFO(this->get_logger(), "Communication to Sensor set up");
+
+  // Read sensor specific configurations
+  readTypeCodeSettings();
+
+  if (m_use_pers_conf)
+  {
+    readPersistentConfig();
+  }
+  m_msg_creator = std::make_unique<sick::MessageCreator>(
+    m_frame_id, m_time_offset, m_range_min, m_range_max, m_angle_offset, m_min_intensities);
 
   RCLCPP_INFO(this->get_logger(), "Node Configured"); 
 
@@ -447,7 +447,7 @@ SickSafetyscannersLifeCycle::parametersCallback(std::vector<rclcpp::Parameter> p
 
 void SickSafetyscannersLifeCycle::receiveUDPPaket(const sick::datastructure::Data& data)
 {
-  if (!data.getMeasurementDataPtr()->isEmpty() && !data.getDerivedValuesPtr()->isEmpty())
+  if (!data.getMeasurementDataPtr()->isEmpty() && !data.getDerivedValuesPtr()->isEmpty() && m_msg_creator)
   {
     auto scan = m_msg_creator->createLaserScanMsg(data, this->now());
     m_laser_scan_publisher->publish(scan);


### PR DESCRIPTION
Bug Reason:
- m_msg_creator variable was initialized _after_ UDP callback function was established so whenever a UDP packet came, if it so happened that m_msg_creator was not initialized yet, it would crash because the callback function accesses m_msg_creator 

Fix:
- Added a check in UDP callback function for m_msg_creator object is not null.
- Moved the m_msg_creator initialization statement from on_activate() to just after UDP callback initialization in on_configure().

Tests:
- Tested on my user on serena by launching hardware multiple times. Scanner no longer crashed.
- Tested _serena_bringup mapping_launch.py_ on serena and was able to create map by moving around.