### PR TITLE
Move parameters population to configure transition

### DIFF
--- a/src/SickSafetyscannersLifeCycle.cpp
+++ b/src/SickSafetyscannersLifeCycle.cpp
@@ -49,15 +49,18 @@ SickSafetyscannersLifeCycle::SickSafetyscannersLifeCycle(const std::string& node
 {
   RCLCPP_INFO(this->get_logger(), "Initializing SickSafetyscannersLifeCycle ");
 
-  // read parameters!
+  // declare parameters
   initialize_parameters();
-  load_parameters();
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 SickSafetyscannersLifeCycle::on_configure(const rclcpp_lifecycle::State&)
 {
   RCLCPP_INFO(this->get_logger(), "on_configure()...");
+
+  // Populate Parameters
+  load_parameters();
+
   sick::types::port_t tcp_port{2122};
 
   // Dynamic Parameter Change client

--- a/src/SickSafetyscannersLifeCycle.cpp
+++ b/src/SickSafetyscannersLifeCycle.cpp
@@ -85,6 +85,9 @@ SickSafetyscannersLifeCycle::on_configure(const rclcpp_lifecycle::State&)
               std::placeholders::_2));
 
 
+  m_msg_creator = std::make_unique<sick::MessageCreator>(
+    m_frame_id, m_time_offset, m_range_min, m_range_max, m_angle_offset, m_min_intensities);
+
   // Bind callback
   std::function<void(const sick::datastructure::Data&)> callback =
     std::bind(&SickSafetyscannersLifeCycle::receiveUDPPaket, this, std::placeholders::_1);
@@ -125,7 +128,7 @@ SickSafetyscannersLifeCycle::on_activate(const rclcpp_lifecycle::State&)
   // Start async receiving and processing of sensor data
   m_device->run();
   m_device->changeSensorSettings(m_communications_settings);
-
+    
   m_laser_scan_publisher->on_activate();
   m_extended_laser_scan_publisher->on_activate();
   m_output_paths_publisher->on_activate();


### PR DESCRIPTION
- The constructor should declare the parameters
- The configure step should populate them
- This ensure we don't redeclare parameters when we reconfigure and we can change the parameters after cleaning up a node